### PR TITLE
show all draw options

### DIFF
--- a/examples/hooks/EditControl.tsx
+++ b/examples/hooks/EditControl.tsx
@@ -48,12 +48,12 @@ export default function EditControlFC({ geojson, setGeojson }: Props) {
         onCreated={handleChange}
         onDeleted={handleChange}
         draw={{
-          rectangle: false,
+          rectangle: true,
           circle: true,
           polyline: true,
           polygon: true,
-          marker: false,
-          circlemarker: false,
+          marker: true,
+          circlemarker: true,
         }}
       />
     </FeatureGroup>


### PR DESCRIPTION
Enable all the draw options in React hooks example